### PR TITLE
Require slicer execution model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,10 @@ cmake_minimum_required(VERSION 3.5)
  
 project(CurveCompare)
 
-find_package(GenerateCLP REQUIRED)
-if(GenerateCLP_FOUND)
-  include(${GenerateCLP_USE_FILE})
-else()
-  message(FATAL_ERROR
-          "GenerateCLP not found. Please set GenerateCLP_DIR.")
-endif()
+find_package(SlicerExecutionModel REQUIRED)
+include(${SlicerExecutionModel_USE_FILE})
 
-find_package(ITK COMPONENTS
+find_package(ITK 4 REQUIRED COMPONENTS
   ITKCommon
   ITKIOImageBase
   ITKImageAdaptors
@@ -24,7 +19,10 @@ find_package(ITK COMPONENTS
 )
 include(${ITK_USE_FILE})
 
-find_package(VTK COMPONENTS
+if(NOT VTK_RENDERING_BACKEND)
+  set(VTK_RENDERING_BACKEND OpenGL)
+endif()
+find_package(VTK REQUIRED COMPONENTS
   vtkCommonComputationalGeometry
   vtkCommonCore
   vtkCommonDataModel
@@ -32,18 +30,14 @@ find_package(VTK COMPONENTS
   vtkIOLegacy
   vtkIOXML
   vtkInteractionWidgets
+  vtkRendering${VTK_RENDERING_BACKEND}
   vtkViewsInfovis
 )
 include(${VTK_USE_FILE})
 
-if( ${ITK_VERSION_MAJOR} VERSION_LESS 4 )
-  message( FATAL_ERROR "CurveCompare needs ITKv4 to compile" )
-endif()
+SEMMacroBuildCLI(
+  NAME CurveCompare
+  TARGET_LIBRARIES ${ITK_LIBRARIES} ${VTK_LIBRARIES}
+  EXECUTABLE_ONLY
+  )
 
-include_directories(${PROJECT_SOURCE_DIR})
-
-set(src CurveCompare.cxx)
-GENERATECLP(src CurveCompare.xml)
-add_executable( CurveCompare ${src})
-
-target_link_libraries( CurveCompare ${ITK_LIBRARIES} ${VTK_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.5)
  
-PROJECT(CurveCompare)
+project(CurveCompare)
 
-FIND_PACKAGE(GenerateCLP REQUIRED)
-IF(GenerateCLP_FOUND)
-  INCLUDE(${GenerateCLP_USE_FILE})
-ELSE(GenerateCLP_FOUND)
-  MESSAGE(FATAL_ERROR
+find_package(GenerateCLP REQUIRED)
+if(GenerateCLP_FOUND)
+  include(${GenerateCLP_USE_FILE})
+else()
+  message(FATAL_ERROR
           "GenerateCLP not found. Please set GenerateCLP_DIR.")
-ENDIF(GenerateCLP_FOUND)
+endif()
 
 find_package(ITK COMPONENTS
   ITKCommon
@@ -42,8 +42,8 @@ endif()
 
 include_directories(${PROJECT_SOURCE_DIR})
 
-SET(src CurveCompare.cxx)
+set(src CurveCompare.cxx)
 GENERATECLP(src CurveCompare.xml)
-ADD_EXECUTABLE( CurveCompare ${src})
+add_executable( CurveCompare ${src})
 
-TARGET_LINK_LIBRARIES( CurveCompare ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries( CurveCompare ${ITK_LIBRARIES} ${VTK_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
  
 PROJECT(CurveCompare)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#CurveCompare
+# CurveCompare
 
-##What is it?
+## What is it?
 
 Compares two fibers file with different metrics: euclidean distance (closest points), tangent metric, curvature metric, overlap, probabilistic overlap
 
-##License
+## License
 
 See Licence.txt
 
-##More information
+## More information
 
-This project can be compiled as an external project while compiling niral_utilities (https://github.com/NIRALUser/niral_utilities)
+This project can be compiled as an external project while compiling [niral_utilities](https://github.com/NIRALUser/niral_utilities)


### PR DESCRIPTION
This PR updates the project to follow the best practice and use `SEMMAcroBuildCLI` to build the executable. 

```
$ rm -rf *

cmake \
  -DSlicerExecutionModel_DIR:PATH=/home/jcfr/Projects/SlicerExecutionModel-Release/ \
  -DVTK_DIR:PATH=/home/jcfr/Projects/Slicer-2-build/VTKv8-build \
  -DSlicerExecutionModel_CLI_RUNTIME_OUTPUT_DIRECTORY:PATH=$(pwd)  \
  ../CurveCompare 
-- The C compiler identification is GNU 5.2.1
-- The CXX compiler identification is GNU 5.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring SEM CLI module: CurveCompare
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/CurveCompare-build

$ make -j5
[ 20%] Generating CurveCompareCLP.h
GenerateCLP --InputXML /tmp/CurveCompare/CurveCompare.xml --OutputCxx /tmp/CurveCompare-build/CurveCompareCLP.h
GenerateCLP: Found 1 parameters groups
GenerateCLP: Group "" has 9 parameters
Scanning dependencies of target CurveCompareLib
[ 40%] Building CXX object CMakeFiles/CurveCompareLib.dir/CurveCompare.cxx.o
[ 60%] Linking CXX static library lib/libCurveCompareLib.a
[ 60%] Built target CurveCompareLib
Scanning dependencies of target CurveCompare
[ 80%] Building CXX object CMakeFiles/CurveCompare.dir/home/jcfr/Projects/SlicerExecutionModel/CMake/SEMCommandLineLibraryWrapper.cxx.o
[100%] Linking CXX executable CurveCompare
Copying XML file 'CurveCompare.xml' along side the executable
[100%] Built target CurveCompare

$ ./CurveCompare --help

USAGE: 

   ./CurveCompare  [--returnparameterfile <std::string>]
                   [--processinformationaddress <std::string>] [--xml]
                   [--echo] [-o <std::string>] [-n <int>] [--voxel_label
                   <int>] [--stepI <double>] [-s <double>] [-m
                   <std::vector<std::string>>] [-R <std::string>]
                   [--vtk_input2 <std::string>] [--vtk_input1
                   <std::string>] [--] [--version] [-h]


Where: 

   --returnparameterfile <std::string>
     Filename in which to write simple return parameters (int, float,
     int-vector, etc.) as opposed to bulk return parameters (image,
     geometry, transform, measurement, table).

   --processinformationaddress <std::string>
     Address of a structure to store process information (progress, abort,
     etc.). (default: 0)

   --xml
     Produce xml description of command line arguments (default: 0)

   --echo
     Echo the command line arguments (default: 0)

   -o <std::string>,  --output_stat_file <std::string>
     Output stat file name (.csv)

   -n <int>,  --number_of_entries <int>
     Number of entries define the number of lines there will be in the
     table (default: 100)

   --voxel_label <int>
     Label for voxelized fiber (default: 1)

   --stepI <double>
     StepInterpolate define the scale to interpolate the two fibers that we
     compare (for the tangent and curve metric) (default: -1)

   -s <double>,  --step <double>
     Step define the scale for the distance axis (default: -1)

   -m <std::vector<std::string>>,  --methods <std::vector<std::string>>
     List of methods to compute: 'Overlap', 'Mean', 'Hausdorff', 'None'
     (default: Mean,Hausdorff)

   -R <std::string>,  --reference_volume <std::string>
     Reference volume to create the label images to compute the overlap of
     the two fibers, the reference scalar image should fit the two fibers
     space

   --vtk_input2 <std::string>
     Second vtk file to compare

   --vtk_input1 <std::string>
     First vtk file to compare

   --,  --ignore_rest
     Ignores the rest of the labeled arguments following this flag.

   --version
     Displays version information and exits.

   -h,  --help
     Displays usage information and exits.


   Description: 
Author(s): Jean-Baptiste Berger,Gwendoline Roger

vtkDebugLeaks has found no leaks.
```